### PR TITLE
chore: avoid add action run when the account it's eosio

### DIFF
--- a/webapp/src/language/en.lacchain.json
+++ b/webapp/src/language/en.lacchain.json
@@ -20,6 +20,10 @@
     "entityType1": "Partner",
     "entityType2": "Non-Partner"
   },
+  "lacchainAddEntityActionEntityTypeFieldComponent": {
+    "entityType1": "Partner",
+    "entityType2": "Non-Partner"
+  },
   "lacchainManagement": {
     "loginWarning": "Please login with your LACChain account to use this feature.",
     "noneActionWarning": "There is no actions available for your account.",

--- a/webapp/src/utils/eos.js
+++ b/webapp/src/utils/eos.js
@@ -7,7 +7,10 @@ export const signTransaction = (ual, transaction) => {
 
   const actions = []
 
-  if (eosConfig.includeDefaultTransaction) {
+  if (
+    ual.activeUser.accountName !== 'eosio' &&
+    eosConfig.includeDefaultTransaction
+  ) {
     actions.push(eosConfig.includeDefaultTransaction)
   }
 


### PR DESCRIPTION
### Fix error on sign transaction

### What does this PR do?

- Avoid use the actin run when the account it's `eosio`

### Steps to test

1. make run lacchain 
2. login with `eosio` account
3. navigate to http://localhost:3000/lacchain/management
4. execute some transaction

#### CheckList

- [x] Follow proper Markdown format
- [x] The content is adequate
- [x] The content is available in both english and spanish
- [x] I Ran a spell check
