### PR TITLE
fix(hapi): increase timeout to avoid empty bpjson

### DIFF
--- a/hapi/src/utils/axios.util.js
+++ b/hapi/src/utils/axios.util.js
@@ -3,11 +3,11 @@ const http = require('http')
 const https = require('https')
 
 const instance = axios.create({
-  timeout: 10000,
-  httpAgent: new http.Agent({ timeout: 30000 }),
+  timeout: 30000,
+  httpAgent: new http.Agent({ timeout: 60000 }),
   httpsAgent: new https.Agent({
     rejectUnauthorized: false,
-    timeout: 30000
+    timeout: 60000
   })
 })
 


### PR DESCRIPTION
### Title

### What does this PR do?

Increase timeout to avoid empty bpJson
