### PR TITLE
fix: missing filter for active producers

### DIFF
--- a/hapi/src/services/eosio.service.js
+++ b/hapi/src/services/eosio.service.js
@@ -24,6 +24,8 @@ const getProducers = async () => {
     producers.push(...rows)
   }
 
+  producers = producers.filter(producer => !!producer.is_active)
+
   const rewards = await getExpectedRewards(producers, totalVoteWeight)
 
   producers = await Promise.all(


### PR DESCRIPTION
### Add missing filter for active producers

### What does this PR do?

- Resolve #674

### Steps to test

1. make run jungle
2. navigate to http://localhost:3000/block-producers

#### CheckList

- [x] Follow proper Markdown format
- [x] The content is adequate
- [x] The content is available in both english and spanish
- [x] I Ran a spell check
