### PR TITLE
fix: missing data for eosauthority

### DIFF
--- a/hapi/src/services/eosio.service.js
+++ b/hapi/src/services/eosio.service.js
@@ -162,6 +162,13 @@ const getBPJsonUrl = async (producer = {}) => {
     producerUrl = 'https://infinitystones.io'
   }
 
+  if (producer.owner === 'eosauthority') {
+    producerUrl =
+      'https://ipfs.eosio.cr/ipfs/QmVDRzUbnJLLM27nBw4FPWveaZ4ukHXAMZRzkbRiTZGdnH'
+
+    return producerUrl
+  }
+
   const chainsUrl = `${producerUrl}/chains.json`.replace(
     /(?<=:\/\/.*)((\/\/))/,
     '/'


### PR DESCRIPTION
### fix missing data for eosauthority

### What does this PR do?

- Resolve #665 

### Steps to test

1. make run mainnet
2. navigate to http://localhost:3000/block-producers
3. take a look to eosauthority data

#### CheckList

- [x] Follow proper Markdown format
- [x] The content is adequate
- [x] The content is available in both english and spanish
- [x] I Ran a spell check
