### PR TITLE
Fix/pagination bug on nodes page 901

### DIFF
--- a/webapp/src/components/InformationCard/Media.js
+++ b/webapp/src/components/InformationCard/Media.js
@@ -9,7 +9,7 @@ const Media = ({ media }) => {
     <>
       <ProducerAvatar logo={media.logo} name={media.name} />
       <Typography className="bpName">{media.name}</Typography>
-      <Typography>{media.account}</Typography>
+      <Typography>{media.account?.toString()}</Typography>
     </>
   )
 }

--- a/webapp/src/hooks/customHooks/useNodeState.js
+++ b/webapp/src/hooks/customHooks/useNodeState.js
@@ -21,7 +21,7 @@ const useNodeState = () => {
     const index = (pagination.page - 1) * pagination.limit
 
     setItems(nodes.slice(index, index + pagination.limit))
-    
+
     setPagination((prev) => ({
       ...prev,
       pages: Math.ceil((nodes?.length ?? 0) / pagination.limit),
@@ -31,14 +31,13 @@ const useNodeState = () => {
   useEffect(() => {
     if (!producers) return
 
-    let nodesList = []
+    const nodesList = []
 
     producers.forEach((producer) => {
       (producer?.bp_json?.nodes ?? []).forEach((node) => {
         if (filters.name === 'all' || node.node_type?.includes(filters.name)) {
           nodesList.push({ node, producer })
         }
-
       })
     })
 

--- a/webapp/src/hooks/customHooks/useNodeState.js
+++ b/webapp/src/hooks/customHooks/useNodeState.js
@@ -7,45 +7,42 @@ import useSearchState from './useSearchState'
 
 const useNodeState = () => {
   const [
-    { filters, pagination, loading, producers, info },
+    { filters, pagination, loading, producers },
     { handleOnSearch, handleOnPageChange, setPagination },
   ] = useSearchState({ query: NODES_QUERY })
   const [items, setItems] = useState([])
+  const [nodes, setNodes] = useState([])
 
   const chips = [{ name: 'all' }, ...eosConfig.nodeTypes]
 
   useEffect(() => {
-    if (!info) return
+    if (!nodes) return
+
+    const index = (pagination.page - 1) * pagination.limit
+
+    setItems(nodes.slice(index, index + pagination.limit))
 
     setPagination((prev) => ({
       ...prev,
-      pages: Math.ceil(info.producers?.count / pagination.limit),
+      pages: Math.ceil((nodes?.length ?? 0) / pagination.limit),
     }))
-  }, [info, pagination.limit, setPagination])
+  }, [nodes, pagination.page, pagination.limit, setPagination])
 
   useEffect(() => {
-    let items = producers || []
+    if (!producers) return
 
-    if (items?.length && filters.name !== 'all') {
-      items = items
-        .map((producer) => {
-          const nodes = (producer.bp_json?.nodes || []).filter(
-            (node) => node.node_type === filters.name,
-          )
+    let nodesList = []
 
-          return {
-            ...producer,
-            bp_json: {
-              ...producer.bp_json,
-              nodes,
-            },
-          }
-        })
-        .filter((producer) => producer?.bp_json?.nodes.length)
-    }
+    producers.forEach((producer) => {
+      (producer?.bp_json?.nodes ?? []).forEach((node) => {
+        if (filters.name === 'all' || node.node_type?.includes(filters.name)) {
+          nodesList.push({ node, producer })
+        }
+      })
+    })
 
-    setItems(items)
-  }, [filters, producers])
+    setNodes(nodesList)
+  }, [filters.name, producers])
 
   return [
     { filters, chips, loading, items, pagination },

--- a/webapp/src/hooks/customHooks/useNodeState.js
+++ b/webapp/src/hooks/customHooks/useNodeState.js
@@ -21,7 +21,7 @@ const useNodeState = () => {
     const index = (pagination.page - 1) * pagination.limit
 
     setItems(nodes.slice(index, index + pagination.limit))
-
+    
     setPagination((prev) => ({
       ...prev,
       pages: Math.ceil((nodes?.length ?? 0) / pagination.limit),
@@ -38,6 +38,7 @@ const useNodeState = () => {
         if (filters.name === 'all' || node.node_type?.includes(filters.name)) {
           nodesList.push({ node, producer })
         }
+
       })
     })
 

--- a/webapp/src/hooks/customHooks/useSearchState.js
+++ b/webapp/src/hooks/customHooks/useSearchState.js
@@ -38,7 +38,10 @@ const useSearchState = ({ query }) => {
     loadProducers({
       variables: {
         where: pagination.where,
-        offset: pagination.offset === undefined ? 0 : (pagination.page - 1) * pagination.limit,
+        offset:
+          pagination.offset === undefined
+            ? 0
+            : (pagination.page - 1) * pagination.limit,
         limit: pagination.limit,
       },
     })

--- a/webapp/src/hooks/customHooks/useSearchState.js
+++ b/webapp/src/hooks/customHooks/useSearchState.js
@@ -38,12 +38,12 @@ const useSearchState = ({ query }) => {
     loadProducers({
       variables: {
         where: pagination.where,
-        offset: pagination.offset || (pagination.page - 1) * pagination.limit,
+        offset: pagination.offset === undefined ? 0 : (pagination.page - 1) * pagination.limit,
         limit: pagination.limit,
       },
     })
     // eslint-disable-next-line
-  }, [pagination.where, pagination.page, pagination.limit])
+  }, [pagination.where, pagination.page, pagination.limit, pagination.offset])
 
   useEffect(() => {
     const params = queryString.parse(location.search)

--- a/webapp/src/routes/Nodes/index.js
+++ b/webapp/src/routes/Nodes/index.js
@@ -17,7 +17,7 @@ const NoResults = lazy(() => import('../../components/NoResults'))
 
 const useStyles = makeStyles(styles)
 
-const NodesCards = ({ item }) => {
+const NodesCards = ({ node, producer }) => {
   const classes = useStyles()
   const { data, loading } = useSubscription(BLOCK_TRANSACTIONS_HISTORY)
   const [missedBlocks, setMissedBlocks] = useState({})
@@ -28,26 +28,13 @@ const NodesCards = ({ item }) => {
     }
   }, [data, loading])
 
-  if (!item.bp_json?.nodes) {
-    return (
-      <div className={classes.card}>
-        <InformationCard producer={item} type="node" />
-      </div>
-    )
-  }
-
   return (
-    <>
-      {(item.bp_json?.nodes || []).map((node, index) => (
-        <div className={classes.card}>
-          <InformationCard
-            producer={{ ...item, node, missedBlocks }}
-            type="node"
-            key={`${node.name}-${index}`}
-          />
-        </div>
-      ))}
-    </>
+    <div className={classes.card} key={`${node.node_type}-${producer.owner}-${node.index}`}>
+      <InformationCard
+        producer={{ ...producer, node, missedBlocks }}
+        type="node"
+      />
+    </div>
   )
 }
 
@@ -76,17 +63,18 @@ const Nodes = () => {
         <>
           <div className={classes.container}>
             {!!items?.length ? (
-              items.map((producer) => (
+              items.map(({node,producer},index) => (
                 <NodesCards
-                  item={producer}
-                  key={`producer_${producer.owner}`}
+                  node={{index,...node}}
+                  producer={producer}
+                  key={`node-${producer.owner}-${index}`}
                 />
               ))
             ) : (
               <NoResults />
             )}
           </div>
-          {pagination.pages > 1 && (
+          {pagination.pages > 0 && (
             <Pagination
               className={classes.pagination}
               count={pagination.pages}

--- a/webapp/src/routes/Nodes/index.js
+++ b/webapp/src/routes/Nodes/index.js
@@ -29,7 +29,10 @@ const NodesCards = ({ node, producer }) => {
   }, [data, loading])
 
   return (
-    <div className={classes.card} key={`${node.node_type}-${producer.owner}-${node.index}`}>
+    <div
+      className={classes.card}
+      key={`${node.node_type}-${producer.owner}-${node.index}`}
+    >
       <InformationCard
         producer={{ ...producer, node, missedBlocks }}
         type="node"
@@ -63,9 +66,9 @@ const Nodes = () => {
         <>
           <div className={classes.container}>
             {!!items?.length ? (
-              items.map(({node,producer},index) => (
+              items.map(({ node, producer }, index) => (
                 <NodesCards
-                  node={{index,...node}}
+                  node={{ index, ...node }}
                   producer={producer}
                   key={`node-${producer.owner}-${index}`}
                 />


### PR DESCRIPTION
### Pagination bug

### What does this PR do?

- Resolve #901
- The pagination used the length of the producers instead of the nodes.

### Steps to test

1. Run the project locally
1. Go to nodes page
1. Test the search
1. Check that the pagination splits the results correctly.

#### CheckList

- [ ] The content is adequate
- [ ] The content is available in both english and spanish
- [ ] I Ran a spell check
