### PR TITLE
Fix/wrong network endpoints 890

### DIFF
--- a/hapi/src/services/eosio.service.js
+++ b/hapi/src/services/eosio.service.js
@@ -167,11 +167,8 @@ const getBPJson = async (producerUrl, chainUrl) => {
 
   try {
     const { data: _bpJson } = await axiosUtil.instance.get(bpJsonUrl)
-    bpJson = _bpJson || bpJson
 
-    if (typeof bpJson !== 'object') {
-      bpJson = {}
-    }
+    bpJson = !!_bpJson && typeof _bpJson === 'object' ? _bpJson : bpJson
   } catch (error) {}
 
   return bpJson


### PR DESCRIPTION
### Wrong network endpoints

### What does this PR do?

- Resolve #890
- Avoid loading nodes and endpoints from default bpjson of the block producers without a valid record for the current network

### Steps to test

1. Run the project locally 
1. Go to endpoints page
1. Check that there are only endpoints for the current network

### Screenshots

## Libre testnet
![imagen](https://user-images.githubusercontent.com/66583677/192067891-59a3649a-6b2b-43dc-9b80-e3ba06b9ea4d.png)

## Proton testnet
![imagen](https://user-images.githubusercontent.com/66583677/192067913-49e475d2-df0b-42eb-ae92-efe603bcfb99.png)

#### CheckList

- [ ] Follow proper Markdown format
- [ ] The content is adequate
- [ ] The content is available in both english and spanish
- [ ] I Ran a spell check
